### PR TITLE
Bump spring.version from 5.0.7.RELEASE to 5.2.7.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<properties>
 		<!-- versions -->
 		
-		<spring.version>5.0.7.RELEASE</spring.version>
+		<spring.version>5.2.7.RELEASE</spring.version>
 		<junit.version>4.12</junit.version>
 		<log4j.version>1.2.17</log4j.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Bumps `spring.version` from 5.0.7.RELEASE to 5.2.7.RELEASE.

Updates `spring-core` from 5.0.7.RELEASE to 5.2.7.RELEASE
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v5.0.7.RELEASE...v5.2.7.RELEASE)

Updates `spring-web` from 5.0.7.RELEASE to 5.2.7.RELEASE
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v5.0.7.RELEASE...v5.2.7.RELEASE)

Updates `spring-webmvc` from 5.0.7.RELEASE to 5.2.7.RELEASE
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v5.0.7.RELEASE...v5.2.7.RELEASE)

Updates `spring-context` from 5.0.7.RELEASE to 5.2.7.RELEASE
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v5.0.7.RELEASE...v5.2.7.RELEASE)

Signed-off-by: dependabot[bot] <support@github.com>